### PR TITLE
Fix popup's elements leak

### DIFF
--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -116,6 +116,9 @@ window.osu =
     $alert = $('.popup-clone').clone()
 
     closeAlert = -> $alert.click()
+    
+    # https://getbootstrap.com/docs/4.0/components/alerts/#methods
+    disposeAlertWithFadeOut = -> $alert.fadeOut().alert('close')
 
     # handle types of alerts by changing the colour
     $alert
@@ -131,7 +134,7 @@ window.osu =
         .one('click.close-alert', closeAlert)
         .fadeIn()
     else
-      Timeout.set 5000, closeAlert
+      Timeout.set 5000, -> disposeAlertWithFadeOut
 
     document.activeElement.blur?()
     $alert.appendTo($popup).fadeIn()


### PR DESCRIPTION
Popups are not removed from the DOM if they are closed by a timer, not manually by "x-mark" button